### PR TITLE
docs: clarify fee token liquidity depends on active proposer preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ If you are unsure which Tempo repository your issue belongs to, open it here and
 
 ## Security
 If you believe you've found a security vulnerability, please do not report it via GitHub issues. Instead, email security@tempo.xyz and we will acknowledge your report within 5 days and provide a more detailed follow-up within 10 days.
+
+## Troubleshooting
+
+- Fee token: simulate OK but send FAIL? See docs/fee-token-troubleshooting.md

--- a/docs/fee-token-troubleshooting.md
+++ b/docs/fee-token-troubleshooting.md
@@ -1,0 +1,32 @@
+# Fee Token Troubleshooting (Tempo Moderato)
+
+## Symptom: simulate OK, send FAIL (“Internal JSON-RPC error”)
+You may see a `simulate` succeed, but transaction submission fails with a generic wallet/provider error.
+
+In our case, the underlying node rejection (visible via RPC error details) was:
+- “Insufficient liquidity for fee token …”
+
+## Root cause: active proposer/validator preferred token
+Fee liquidity checks depend on the *active proposer/validator’s preferred token*.
+This can change per block.
+
+Practical implication:
+- Having liquidity in `Pool(userToken, AlphaUSD)` may still fail if the current proposer prefers `PathUSD`.
+- The required pool is `Pool(userToken, proposerPreferredToken)`.
+
+## Quick debug steps
+1) Read latest block proposer address:
+   - read latest block `coinbase` (or `miner` depending on RPC)
+2) Read preferred validator token:
+   - call `FeeManager.validatorTokens(coinbase)`
+3) Ensure Fee AMM liquidity exists for:
+   - `Pool(userToken, preferredValidatorToken)`
+   - specifically: `reserveValidatorToken > 0`
+
+## Fix
+Add validator-token liquidity to the pool against the proposer preferred token (often PathUSD on Moderato), then retry:
+- `FeeManager.setUserToken(userToken)`
+
+## Notes
+- `quoteToken` (DEX pricing/routing) does not need to match the validator preferred token.
+- Explorer is the source of truth for which fee token was used; wallet UIs may show a generic chain fee token.


### PR DESCRIPTION
## Summary
Document a common failure mode where `simulate` succeeds but tx submission fails due to fee liquidity checks.

Refs #7.

## Problem
Users may get a generic wallet/provider error (“Internal JSON-RPC error”), while the node rejection is actually:
“Insufficient liquidity for fee token …”

## Root cause
The required Fee AMM pool depends on the *active proposer/validator’s preferred token* (`FeeManager.validatorTokens(latestBlock.coinbase)`), which can differ from assumed defaults.

## Fix / Guidance
Add liquidity to `Pool(userToken, proposerPreferredToken)` (ensure `reserveValidatorToken > 0`), then retry `FeeManager.setUserToken(userToken)`.

## Docs
- Adds `docs/fee-token-troubleshooting.md`
- Links it from README
