### PR TITLE
docs: update README wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 <p align="center">
   <a href="https://tempo.xyz">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tempoxyz/.github/refs/heads/main/assets/combomark-dark.svg">
-      <img alt="tempo combomark" src="https://raw.githubusercontent.com/tempoxyz/.github/refs/heads/main/assets/combomark-bright.svg" width="auto" height="120">
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/tempoxyz/tempo/refs/heads/main/.github/assets/tempo-wordmark-white.svg">
+      <img alt="Tempo wordmark" src="https://raw.githubusercontent.com/tempoxyz/tempo/refs/heads/main/.github/assets/tempo-wordmark-black.svg" width="360">
     </picture>
   </a>
 </p>


### PR DESCRIPTION
Updates the README header to use the official Tempo wordmark assets from `tempoxyz/tempo`, matching tempoxyz/tempo#4613.

This removes the old dependency on the org-level combomark assets and keeps GitHub light/dark rendering aligned with the current brand kit wordmark.

Prompted by: @Slokh
